### PR TITLE
feat: add pdv lambda expose usage plan details infra

### DIFF
--- a/src/main/.terraform.lock.hcl
+++ b/src/main/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.46.0"
-  constraints = ">= 2.49.0, >= 4.0.0, >= 4.27.0, >= 4.59.0, >= 5.0.0, >= 5.46.0, 5.46.0"
+  constraints = ">= 2.49.0, >= 4.0.0, >= 4.27.0, >= 4.59.0, >= 4.63.0, >= 5.0.0, >= 5.46.0, 5.46.0"
   hashes = [
     "h1:d0Mf33mbbQujZ/JaYkqmH5gZGvP+iEIWf9yBSiOwimE=",
     "zh:05ae6180a7f23071435f6e5e59c19af0b6c5da42ee600c6c1568c8660214d548",
@@ -24,8 +24,49 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.3.5"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.5.3"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.2.3"
+  version     = "3.2.3"
+  constraints = ">= 2.0.0"
   hashes = [
     "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
     "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",

--- a/src/main/01-locals.tf
+++ b/src/main/01-locals.tf
@@ -10,6 +10,8 @@ locals {
 
   api_key_list = { for k in var.user_registry_plans : k.key_name => k }
 
+  plan_details_api_key_list = { for k in var.plan_details_plans : k.key_name => k }
+
   additional_keys = flatten([for k in var.user_registry_plans :
     [for a in k.additional_keys :
       {

--- a/src/main/31-api-keys.tf
+++ b/src/main/31-api-keys.tf
@@ -8,3 +8,8 @@ resource "aws_api_gateway_api_key" "additional" {
   for_each = { for k in local.additional_keys : k.key => k }
   name     = each.key
 }
+
+resource "aws_api_gateway_api_key" "plan_details" {
+  for_each = local.plan_details_api_key_list
+  name     = each.key
+}

--- a/src/main/36-plan-details.tf
+++ b/src/main/36-plan-details.tf
@@ -1,0 +1,111 @@
+
+# Lambda module configuration
+module "lambda_usage_plan_details" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "6.8.0"
+
+  function_name           = "usage-plan-details"
+  description             = "API to retrieve usage plan api keys details"
+  handler                 = "index.lambda_handler"
+  runtime                 = "python3.10"
+  ignore_source_code_hash = true
+
+  create_package         = false
+  local_existing_package = "../lambda/hello-python/lambda.zip"
+
+  # Environment variables if needed
+  cloudwatch_logs_retention_in_days = 14
+  environment_variables = {
+    LOG_LEVEL   = "INFO"
+    REST_API_ID = aws_api_gateway_rest_api.user_registry.id
+  }
+
+  timeout = 30
+
+  # Attach policies
+  attach_policy_statements = true
+  policy_statements = {
+    apigateway = {
+      effect = "Allow"
+      actions = [
+        "apigateway:GET",
+      ]
+      resources = [
+        "arn:aws:apigateway:${var.aws_region}::/apikeys",
+        "arn:aws:apigateway:${var.aws_region}::/apikeys/*",
+        "arn:aws:apigateway:${var.aws_region}::/usageplans",
+        "arn:aws:apigateway:${var.aws_region}::/usageplans/*"
+      ]
+    }
+  }
+
+  # lambda powertools layer
+  layers = [
+    "arn:aws:lambda:${var.aws_region}:017000801446:layer:AWSLambdaPowertoolsPythonV3-python312-x86_64:11"
+  ]
+
+}
+
+
+# Role to deploy the lambda functions with github actions
+
+locals {
+  assume_role_plan_details_policy_github = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = "arn:aws:iam::${data.aws_caller_identity.current.id}:oidc-provider/token.actions.githubusercontent.com"
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" : [
+              "repo:pagopa/pdv-lambda-expose-usage-plan-details:environment:dev",
+              "repo:pagopa/pdv-lambda-expose-usage-plan-details:environment:uat",
+              "repo:pagopa/pdv-lambda-expose-usage-plan-details:environment:prod",
+              "repo:pagopa/pdv-lambda-expose-usage-plan-details:ref:refs/heads/main"
+            ]
+          }
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "deploy_lambda_usage_plan_details" {
+  name        = "DeployLambda"
+  description = "Policy to deploy Lambda functions"
+
+  policy = jsonencode({
+
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:CreateFunction",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "github_lambda_usage_plan_details_deploy" {
+  name               = "GitHubLambdaUsagePlanDetailsDeploy"
+  description        = "Role to deploy lambda functions with github actions."
+  assume_role_policy = local.assume_role_plan_details_policy_github
+}
+
+
+resource "aws_iam_role_policy_attachment" "github_lambda_usage_plan_details_deploy" {
+  role       = aws_iam_role.github_lambda_usage_plan_details_deploy.name
+  policy_arn = aws_iam_policy.deploy_lambda_usage_plan_details.arn
+}

--- a/src/main/37-api-plan-details.tf
+++ b/src/main/37-api-plan-details.tf
@@ -164,7 +164,7 @@ resource "aws_apigatewayv2_api_mapping" "plan_details" {
   api_id          = aws_api_gateway_rest_api.plan_details.id
   stage           = local.plan_details_stage_name
   domain_name     = aws_api_gateway_domain_name.main[0].domain_name
-  api_mapping_key = format("plan-details/%s", aws_api_gateway_stage.plan_details.stage_name)
+  api_mapping_key = "plan-details"
 }
 
 ## WAF association

--- a/src/main/37-api-plan-details.tf
+++ b/src/main/37-api-plan-details.tf
@@ -1,0 +1,183 @@
+locals {
+  plan_details_api_name       = format("%s-plan-details-api", local.project)
+  plan_details_stage_name     = "v1"
+  plan_details_log_group_name = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.plan_details.id}/${local.plan_details_stage_name}"
+}
+
+## Role that allows api gateway to invoke lambda functions.
+data "aws_iam_policy_document" "apigw_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["apigateway.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda_apigw_proxy" {
+  name               = "${local.plan_details_api_name}-lambda-proxy"
+  assume_role_policy = data.aws_iam_policy_document.apigw_assume_role.json
+}
+
+data "aws_iam_policy_document" "lambda_apigw_proxy" {
+  statement {
+    effect    = "Allow"
+    actions   = ["lambda:InvokeFunction"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "lambda_apigw_proxy" {
+  name        = "apigw-invoke-lambda"
+  description = "Lambda invoke policy"
+  policy      = data.aws_iam_policy_document.lambda_apigw_proxy.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_apigw_proxy" {
+  role       = aws_iam_role.lambda_apigw_proxy.name
+  policy_arn = aws_iam_policy.lambda_apigw_proxy.arn
+}
+
+resource "aws_api_gateway_rest_api" "plan_details" {
+  name           = local.plan_details_api_name
+  api_key_source = "HEADER"
+
+  body = templatefile("./api/ms_user_registry/api-expose-usage-plan-details.tpl.json",
+    {
+      uri                           = format("http://%s:%s", module.nlb.lb_dns_name, var.container_port_user_registry),
+      connection_id                 = aws_api_gateway_vpc_link.apigw.id
+      lambda_usage_plan_details_arn = module.lambda_usage_plan_details.lambda_function_arn
+      lambda_apigateway_proxy_role  = aws_iam_role.lambda_apigw_proxy.arn
+      aws_region                    = var.aws_region
+    }
+  )
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+
+  disable_execute_api_endpoint = var.apigw_custom_domain_create
+
+  tags = { Name = local.plan_details_api_name }
+}
+
+resource "aws_api_gateway_deployment" "plan_details" {
+  rest_api_id = aws_api_gateway_rest_api.plan_details.id
+  # stage_name  = local.plan_details_stage_name
+
+  triggers = {
+    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.plan_details.body))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "plan_details" {
+  name              = local.plan_details_log_group_name
+  retention_in_days = var.apigw_execution_logs_retention
+
+  tags = { Name = local.plan_details_api_name }
+
+}
+resource "aws_api_gateway_stage" "plan_details" {
+  deployment_id      = aws_api_gateway_deployment.plan_details.id
+  rest_api_id        = aws_api_gateway_rest_api.plan_details.id
+  stage_name         = local.plan_details_stage_name
+  cache_cluster_size = 0.5 #why is this needed ?
+  # documentation_version = aws_api_gateway_documentation_version.main.version
+  xray_tracing_enabled = true
+
+  dynamic "access_log_settings" {
+    for_each = var.apigw_access_logs_enable ? ["dymmy"] : []
+    content {
+      destination_arn = aws_cloudwatch_log_group.plan_details.arn
+      #todo: find a better way to represent this log format.
+      format = "{ \"requestId\":\"$context.requestId\", \"extendedRequestId\":\"$context.extendedRequestId\", \"ip\": \"$context.identity.sourceIp\", \"caller\":\"$context.identity.caller\", \"user\":\"$context.identity.user\", \"requestTime\":\"$context.requestTime\", \"httpMethod\":\"$context.httpMethod\", \"resourcePath\":\"$context.resourcePath\", \"status\":\"$context.status\", \"protocol\":\"$context.protocol\", \"responseLength\":\"$context.responseLength\"}"
+    }
+  }
+}
+
+resource "aws_api_gateway_method_settings" "plan_details" {
+  rest_api_id = aws_api_gateway_rest_api.plan_details.id
+  stage_name  = local.plan_details_stage_name
+  method_path = "*/*"
+
+  settings {
+    # Enable CloudWatch logging and metrics
+    metrics_enabled    = true
+    data_trace_enabled = var.apigw_data_trace_enabled
+    logging_level      = "ERROR"
+    #todo.
+    # Limit the rate of calls to prevent abuse and unwanted charges
+    #throttling_rate_limit  = 100
+    #throttling_burst_limit = 50
+  }
+}
+
+resource "aws_api_gateway_usage_plan" "plan_details" {
+  for_each    = local.plan_details_api_key_list
+  name        = format("%s-api-plan-%s", local.plan_details_api_name, lower(each.key))
+  description = "Usage plan for plan_details apis"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.plan_details.id
+    stage  = aws_api_gateway_stage.plan_details.stage_name
+
+    dynamic "throttle" {
+      for_each = each.value.method_throttle
+      content {
+        path        = throttle.value.path
+        burst_limit = throttle.value.burst_limit
+        rate_limit  = throttle.value.rate_limit
+      }
+    }
+
+  }
+
+  /*
+  quota_settings {
+    limit  = 20
+    offset = 2
+    period = "WEEK"
+  }
+  */
+  throttle_settings {
+    burst_limit = each.value.burst_limit
+    rate_limit  = each.value.rate_limit
+  }
+}
+
+resource "aws_api_gateway_usage_plan_key" "plan_details" {
+  for_each      = local.plan_details_api_key_list
+  key_id        = aws_api_gateway_api_key.plan_details[each.key].id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.plan_details[each.key].id
+}
+
+
+resource "aws_apigatewayv2_api_mapping" "plan_details" {
+  count           = var.apigw_custom_domain_create ? 1 : 0
+  api_id          = aws_api_gateway_rest_api.plan_details.id
+  stage           = local.plan_details_stage_name
+  domain_name     = aws_api_gateway_domain_name.main[0].domain_name
+  api_mapping_key = format("plan-details/%s", aws_api_gateway_stage.plan_details.stage_name)
+}
+
+## WAF association
+resource "aws_wafv2_web_acl_association" "plan_details" {
+  web_acl_arn  = aws_wafv2_web_acl.main.arn
+  resource_arn = "arn:aws:apigateway:${var.aws_region}::/restapis/${aws_api_gateway_rest_api.plan_details.id}/stages/${aws_api_gateway_stage.plan_details.stage_name}"
+}
+
+output "plan_details_api_keys" {
+  value     = { for k in keys(local.plan_details_api_key_list) : k => aws_api_gateway_usage_plan_key.plan_details[k].value }
+  sensitive = true
+}
+
+output "plan_details_invoke_url" {
+  value = try(aws_api_gateway_deployment.plan_details.invoke_url, null)
+}

--- a/src/main/98-variables.tf
+++ b/src/main/98-variables.tf
@@ -125,6 +125,21 @@ variable "user_registry_plans" {
   description = "Usage plan with its api key and rate limit."
 }
 
+variable "plan_details_plans" {
+  type = list(object({
+    key_name        = string
+    burst_limit     = number
+    rate_limit      = number
+    additional_keys = list(string)
+    method_throttle = list(object({
+      path        = string
+      burst_limit = number
+      rate_limit  = number
+    }))
+  }))
+  description = "Usage plan with its api key and rate limit."
+}
+
 /*
 variable "api_user_registry_throttling" {
   type = object({

--- a/src/main/api/ms_user_registry/api-expose-usage-plan-details.tpl.json
+++ b/src/main/api/ms_user_registry/api-expose-usage-plan-details.tpl.json
@@ -37,7 +37,7 @@
           "httpMethod": "POST",
           "uri": "arn:aws:apigateway:${aws_region}:lambda:path/2015-03-31/functions/${lambda_usage_plan_details_arn}/invocations",
           "responses": {
-            "201": {
+            "200": {
               "statusCode": "200",
               "responseParameters": {}
             },

--- a/src/main/api/ms_user_registry/api-expose-usage-plan-details.tpl.json
+++ b/src/main/api/ms_user_registry/api-expose-usage-plan-details.tpl.json
@@ -1,0 +1,254 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "pdv-lambda-expose-usage-plan-details",
+    "description": "Usage Plan Details API documentation",
+    "version": "1.0-SNAPSHOT"
+  },
+  "servers": [
+    {
+      "url": "${uri}{basePath}",
+      "variables": {
+        "basePath": {
+          "default": "/v1"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "user",
+      "description": "User operations"
+    }
+  ],
+  "paths": {
+    "/api-keys": {
+      "get": {
+        "tags": [
+          "Usage plans"
+        ],
+        "description": "This endpoint returns the list of API keys with id and name.",
+        "operationId": "Get_api_keys",
+        "x-amazon-apigateway-integration": {
+          "credentials": "${lambda_apigateway_proxy_role}",
+          "passthroughBehavior": "when_no_match",
+          "contentHandling": "CONVERT_TO_TEXT",
+          "type": "aws_proxy",
+          "httpMethod": "POST",
+          "uri": "arn:aws:apigateway:${aws_region}:lambda:path/2015-03-31/functions/${lambda_usage_plan_details_arn}/invocations",
+          "responses": {
+            "201": {
+              "statusCode": "200",
+              "responseParameters": {}
+            },
+            "400": {
+              "statusCode": "400",
+              "responseParameters": {}
+            },
+            "401": {
+              "statusCode": "401",
+              "responseParameters": {}
+            },
+            "403": {
+              "statusCode": "403",
+              "responseParameters": {}
+            },
+            "405": {
+              "statusCode": "405",
+              "responseParameters": {}
+            },
+            "429": {
+              "statusCode": "405",
+              "responseParameters": {}
+            },
+            "500": {
+              "statusCode": "500",
+              "responseParameters": {}
+            }
+          }
+        },
+        "summary": "API keys list",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ApiKeysListResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/invalidParameters"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "405": {
+            "$ref": "#/components/responses/methodNotAllowed"
+          },
+          "429": {
+            "$ref": "#/components/responses/rateLimit"
+          },
+          "500": {
+            "$ref": "#/components/responses/serverError"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/validate-api-key": {
+      "post": {
+        "tags": [
+          "Usage plans"
+        ],
+        "description": "This endpoint validates the API key against the API key id both provided in the request body.",
+        "operationId": "Post_validate_api_key",
+        "x-amazon-apigateway-integration": {
+          "credentials": "${lambda_apigateway_proxy_role}",
+          "passthroughBehavior": "when_no_match",
+          "contentHandling": "CONVERT_TO_TEXT",
+          "type": "aws_proxy",
+          "httpMethod": "POST",
+          "uri": "arn:aws:apigateway:${aws_region}:lambda:path/2015-03-31/functions/${lambda_usage_plan_details_arn}/invocations",
+          "responses": {
+            "200": {
+              "statusCode": "200",
+              "responseParameters": {}
+            },
+            "400": {
+              "statusCode": "400",
+              "responseParameters": {}
+            },
+            "401": {
+              "statusCode": "401",
+              "responseParameters": {}
+            },
+            "403": {
+              "statusCode": "403",
+              "responseParameters": {}
+            },
+            "405": {
+              "statusCode": "405",
+              "responseParameters": {}
+            },
+            "429": {
+              "statusCode": "405",
+              "responseParameters": {}
+            },
+            "500": {
+              "statusCode": "500",
+              "responseParameters": {}
+            }
+          }
+        },
+        "summary": "Validate API key",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ValidateApiKeyRequestBody"
+              }
+            }
+          },
+          "description": "Request body",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/ValidateResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/invalidParameters"
+          },
+          "401": {
+            "$ref": "#/components/responses/unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/forbidden"
+          },
+          "405": {
+            "$ref": "#/components/responses/methodNotAllowed"
+          },
+          "429": {
+            "$ref": "#/components/responses/rateLimit"
+          },
+          "500": {
+            "$ref": "#/components/responses/serverError"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ValidateApiKeyRequestBody": {
+        "type": "object",
+        "properties": {
+          "api_key_id": {
+            "type": "string"
+          },
+          "api_key_value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "api_key_id",
+          "api_key_value"
+        ]
+      }
+    },
+    "responses": {
+      "ApiKeysListResponse": {
+        "type": "object",
+        "properties": {
+          "apiKeys": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "name"
+              ]
+            }
+          }
+        },
+        "required": [
+          "apiKeys"
+        ]
+      },
+      "ValidateResponse": {
+        "type": "object",
+        "properties": {
+          "valid": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "valid"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "name": "x-api-key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/src/main/api/ms_user_registry/api-expose-usage-plan-details.tpl.json
+++ b/src/main/api/ms_user_registry/api-expose-usage-plan-details.tpl.json
@@ -39,7 +39,9 @@
           "responses": {
             "200": {
               "statusCode": "200",
-              "responseParameters": {}
+              "responseParameters": {
+                "method.response.header.content-type": "'application/json'"
+              }
             },
             "400": {
               "statusCode": "400",
@@ -115,7 +117,9 @@
           "responses": {
             "200": {
               "statusCode": "200",
-              "responseParameters": {}
+              "responseParameters": {
+                "method.response.header.content-type": "'application/json'"
+              }
             },
             "400": {
               "statusCode": "400",
@@ -206,41 +210,73 @@
     },
     "responses": {
       "ApiKeysListResponse": {
-        "type": "object",
-        "properties": {
-          "apiKeys": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "name"
-              ]
+        "description": "Response containing the list of API keys with id and name (not sensitive data).",
+        "headers": {
+          "content-type": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
             }
           }
         },
-        "required": [
-          "apiKeys"
-        ]
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "apiKeys": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "apiKeys"
+              ]
+            }
+          }
+        }
       },
       "ValidateResponse": {
-        "type": "object",
-        "properties": {
-          "valid": {
-            "type": "boolean"
+        "description": "Response indicating whether the API key is valid or not.",
+        "headers": {
+          "content-type": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
           }
         },
-        "required": [
-          "valid"
-        ]
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "valid": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "valid"
+              ]
+            }
+          }
+        }
       }
     },
     "securitySchemes": {

--- a/src/main/env/dev/terraform.tfvars
+++ b/src/main/env/dev/terraform.tfvars
@@ -81,6 +81,16 @@ user_registry_plans = [
   },
 ]
 
+plan_details_plans = [
+  {
+    key_name        = "PLAN-DETAILS"
+    burst_limit     = 20
+    rate_limit      = 10
+    additional_keys = []
+    method_throttle = []
+  },
+]
+
 
 # dynamodb
 dynamodb_point_in_time_recovery_enabled = false

--- a/src/main/env/prod/terraform.tfvars
+++ b/src/main/env/prod/terraform.tfvars
@@ -117,6 +117,15 @@ user_registry_plans = [
   },
 ]
 
+plan_details_plans = [
+  {
+    key_name        = "PLAN-DETAILS"
+    burst_limit     = 20
+    rate_limit      = 10
+    additional_keys = []
+    method_throttle = []
+  },
+]
 
 ## Web ACL
 

--- a/src/main/env/uat/terraform.tfvars
+++ b/src/main/env/uat/terraform.tfvars
@@ -138,6 +138,16 @@ user_registry_plans = [
   },
 ]
 
+plan_details_plans = [
+  {
+    key_name        = "PLAN-DETAILS"
+    burst_limit     = 20
+    rate_limit      = 10
+    additional_keys = []
+    method_throttle = []
+  },
+]
+
 
 # dynamodb
 dynamodb_point_in_time_recovery_enabled = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
This **PR** expose `usage-plan-details` lambda via dedicated Rest API and dedicated API Key.
Check this [repo](https://github.com/pagopa/pdv-lambda-expose-usage-plan-details) for details about the functionality

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This API is required for upcoming integration between PDV and [OI](https://github.com/pagopa/oneidentity)

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [X] DEV
- [X] UAT
- [X] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
